### PR TITLE
Upgrade Go to v1.20.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/graphsolver-minimal
 
-go 1.19
+go 1.20
 
 require (
 	github.com/test-network-function/graphsolver-lib v0.0.0-20220909223750-81a75bdaf38f


### PR DESCRIPTION
Release Notes: https://tip.golang.org/doc/go1.20

Related to: https://github.com/test-network-function/cnf-certification-test/pull/873